### PR TITLE
Add details for Zed syntax highlighting

### DIFF
--- a/content/docs/syntax-highlighting.md
+++ b/content/docs/syntax-highlighting.md
@@ -14,6 +14,7 @@ If you would like to install a Cooklang syntax highlighting addon for your favor
 * [Vim via GitHub](#vim-via-github)
 * [VSCode via Extensions](#vscode-via-extensions)
 * [Kakoune via GitHub](#kakoune-via-github)
+* [Zed via Extensions](#zed-via-github)
 
 ## Emacs via GitHub
 
@@ -48,3 +49,8 @@ It is highly recommended to install Cooklang with Package Control as it automati
 ## Kakoune Via GitHub
 
 * [Install from here](https://github.com/cooklang/cooklang-kak)
+
+## Zed via Extensions
+
+1. Open the Zed Extension Gallery by opening the command palette and selecting `zed: extensions`.
+2. Find and install Cooklang.

--- a/content/docs/syntax-highlighting.md
+++ b/content/docs/syntax-highlighting.md
@@ -14,7 +14,7 @@ If you would like to install a Cooklang syntax highlighting addon for your favor
 * [Vim via GitHub](#vim-via-github)
 * [VSCode via Extensions](#vscode-via-extensions)
 * [Kakoune via GitHub](#kakoune-via-github)
-* [Zed via Extensions](#zed-via-github)
+* [Zed via Extensions](#zed-via-extensions)
 
 ## Emacs via GitHub
 

--- a/content/docs/syntax-highlighting.md
+++ b/content/docs/syntax-highlighting.md
@@ -46,7 +46,7 @@ It is highly recommended to install Cooklang with Package Control as it automati
 1. Find Cooklang using the Extensions View.
 2. Install an extension.
 
-## Kakoune Via GitHub
+## Kakoune via GitHub
 
 * [Install from here](https://github.com/cooklang/cooklang-kak)
 


### PR DESCRIPTION
This PR adds mention of the Cooklang extension for [Zed, an open-source text editor][1]. I also updated on of the other headers on the page for consistency with the rest of the entries.

This extension uses the Tree-sitter grammar linked in the Cooklang documentation, [addcninblue/tree-sitter-cooklang][2].

You can view the extension itself at [hugginsio/zed-cooklang][3].

[1]: https://github.com/zed-industries/zed
[2]: https://github.com/addcninblue/tree-sitter-cooklang
[3]: https://github.com/hugginsio/zed-cooklang