### PR TITLE
fix(README): replace broken link to Hugo Pipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To start this website locally you will need to have Hugo installed. If you donâ€
 
 ### Check Hugo version (Hugo 0.51+ Extended is required) 
 
-The site  uses [Hugo Pipes](https://gohugo.io/hugo-pipes/scss-sass/) to compile SCSS and minify assets. Please make sure you have the **Hugo Extended** version installed. If you are not using the extended version this theme will not not compile.
+The site  uses [Hugo Pipes](https://gohugo.io/hugo-pipes/) to compile SCSS and minify assets. Please make sure you have the **Hugo Extended** version installed. If you are not using the extended version this theme will not not compile.
 
 To check your version of Hugo, run:
 


### PR DESCRIPTION
The link associated with the text "Hugo Pipes" was broken.

The URL seemed to indicate that the intended link was to https://gohugo.io/hugo-pipes/transpile-sass-to-css/ but I don't find the content of that page particularly relevant. Therefore, I suggest to simply link to the root page about Hugo Pipes. 

Slightly unrelated to this PR, the Hugo docs about transpiling sass to css [states](https://gohugo.io/functions/css/sass/#dart-sass) that Dart Sass is needed to use the latest sass features, but I wasn't sure if it was needed in this case. Could be worth clarifying that in the README. 