### PR TITLE
SEO: internal links to the self-hosting guide, spec 'syntax' title, how-to-double snippet block

### DIFF
--- a/content/blog/18-open-source-recipe-managers-2026.md
+++ b/content/blog/18-open-source-recipe-managers-2026.md
@@ -17,7 +17,7 @@ Here's an honest look at the main options.
 
 **Strengths:**
 - Recipes are plain text — readable, editable, version-controllable
-- No database, no server required for basic use
+- No database, no server required for basic use (a [self-hosted recipe server via Docker](/blog/21-self-hosting-recipes-with-docker/) is optional, not required)
 - Ecosystem of tools: [CookCLI](/cli/) for shopping lists and a local web server, [mobile apps](/app/) for iOS and Android, [Obsidian plugin](/blog/15-cooklang-obsidian-guide/), VS Code extension
 - Sync through whatever you already use (Git, Dropbox, iCloud)
 - [Federation](https://recipes.cooklang.org) for discovering community recipes

--- a/content/blog/26-how-to-scale-recipes-without-mistakes.md
+++ b/content/blog/26-how-to-scale-recipes-without-mistakes.md
@@ -27,6 +27,13 @@ To scale a recipe, multiply each ingredient by **target servings ÷ original ser
 | Pan / cookware size | **Doesn't scale** — bigger batch needs a wider pan, not the same one |
 | Cook time & timers | **Doesn't scale** — a physical property of the process, not the quantity |
 
+### How to double a recipe
+
+1. Multiply flour, liquids, produce, and meat by 2.
+2. Start salt, spices, and acid at 1.5× — taste and adjust at the end.
+3. Use about 1.75× the baking soda, baking powder, or yeast, not 2×.
+4. Split the batch across two pans (or one much wider one) and keep the original cook time as your starting point — check early, not late.
+
 The rest of this post explains each of these, then shows how a structured recipe format makes the arithmetic automatic.
 
 ## Why Scaling Goes Wrong

--- a/content/blog/40-mealie-review.md
+++ b/content/blog/40-mealie-review.md
@@ -122,7 +122,7 @@ Remove the pan from heat. Add the drained pasta, then quickly stir in the egg mi
 Serve immediately with extra cheese and pepper.
 ```
 
-No server required. No database. Any text editor opens it. You can sync it with iCloud, Dropbox, or Git. The [CookCLI](/cli/) generates shopping lists, runs a local recipe server, and handles imports. There are [native mobile apps](/app/) for iOS and Android.
+No server required. No database. Any text editor opens it. You can sync it with iCloud, Dropbox, or Git. The [CookCLI](/cli/) generates shopping lists, runs a local recipe server ([self-hostable with Docker](/blog/21-self-hosting-recipes-with-docker/) if you want it always-on), and handles imports. There are [native mobile apps](/app/) for iOS and Android.
 
 The trade-offs are real. No built-in web scraping with a GUI. No multi-user dashboard. No drag-and-drop meal planner. If those features matter to you, Mealie has them and Cooklang doesn't.
 
@@ -132,7 +132,7 @@ These are different philosophies, not a ranking. Mealie is excellent at what it 
 
 ---
 
-For a side-by-side comparison of Mealie, Paprika, KitchenOwl, and Cooklang across more criteria, see [this full comparison](/blog/09-cooklang-vs-paprika-vs-mealie/).
+For a side-by-side of Mealie vs Paprika vs Cooklang across more criteria, see [the full comparison](/blog/09-cooklang-vs-paprika-vs-mealie/).
 
 If you want to try Cooklang, the [getting started guide](/docs/getting-started/) takes about five minutes.
 

--- a/content/blog/42-tandoor-vs-mealie-vs-kitchenowl.md
+++ b/content/blog/42-tandoor-vs-mealie-vs-kitchenowl.md
@@ -134,7 +134,7 @@ Tandoor is the heaviest, particularly because PostgreSQL is mandatory and the fe
 
 If you are a developer and you want control over your recipe data, there is a different path worth knowing about: plain text files.
 
-Cooklang is a markup language for recipes. You write `.cook` files in any text editor, store them wherever you like — a Git repository, iCloud, Dropbox — and use [CookCLI](/cli/) for shopping lists, scaling, and a local web server. No database, no server, no Docker container to maintain.
+Cooklang is a markup language for recipes. You write `.cook` files in any text editor, store them wherever you like — a Git repository, iCloud, Dropbox — and use [CookCLI](/cli/) for shopping lists, scaling, and a local web server. No database, no server, no Docker container to maintain. (Though if you *want* a browsable server for your household, [self-hosting your recipes with Docker and CookCLI](/blog/21-self-hosting-recipes-with-docker/) takes minutes.)
 
 The trade-off is real: no GUI recipe import, no multi-user dashboard, no polished web interface for non-technical household members. But your recipes are text files. They open in any editor, diff cleanly in Git, survive any app going offline, and never require a migration.
 

--- a/content/blog/48-best-recipe-management-software.md
+++ b/content/blog/48-best-recipe-management-software.md
@@ -73,7 +73,7 @@ Cook @guanciale{100%g} in a #pan{} over medium heat until crispy, about ~{8%minu
 Remove from heat. Add the drained pasta, then stir in the egg mixture quickly. Toss vigorously — residual heat cooks the eggs without scrambling them.
 ```
 
-[CookCLI](/cli/) handles shopping lists, recipe scaling, and runs a local web server. There are native iOS and Android apps. There is an Obsidian plugin if you prefer writing in Obsidian. There is a VS Code extension with syntax highlighting. A community of developers has built tools on top of the spec — Telegram bots, nutrition calculators, Home Assistant integrations, custom scripts.
+[CookCLI](/cli/) handles shopping lists, recipe scaling, and runs a local web server — [self-hostable with Docker](/blog/21-self-hosting-recipes-with-docker/) if you want your collection browsable across your network. There are native iOS and Android apps. There is an Obsidian plugin if you prefer writing in Obsidian. There is a VS Code extension with syntax highlighting. A community of developers has built tools on top of the spec — Telegram bots, nutrition calculators, Home Assistant integrations, custom scripts.
 
 The trade-offs are honest. No GUI recipe import with a polished scraper. No multi-user dashboard with role management. No drag-and-drop meal planner. If those features are load-bearing for you, Cooklang is the wrong tool. But if you want total ownership of your data, a format that will remain readable forever, and a foundation you can build on — Cooklang is the only option in this list that gives you all of that.
 

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -121,7 +121,7 @@ Find curated recipes, share your thoughts, or ask for help:
 
 ### Command-Line Interface (CookCLI)
 
-CookCLI is a command-line tool for automating your recipe workflow. It follows the UNIX philosophy — each command does one thing well and can be combined with other tools.
+[CookCLI](/cli/) is a command-line tool for automating your recipe workflow. It follows the UNIX philosophy — each command does one thing well and can be combined with other tools.
 
 ```bash
 mkdir my-recipes && cd my-recipes         # cook seed fills its target directory, so use a dedicated one

--- a/content/docs/spec.md
+++ b/content/docs/spec.md
@@ -1,5 +1,5 @@
 ---
-title: 'Cooklang Specification'
+title: 'Cooklang Specification & Syntax Reference'
 date: 2026-04-10T18:01:32+00:00
 draft: false
 weight: 2

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -76,7 +76,7 @@
           <p class="text-cooklang-gray-600 mb-4">
             Parse recipes, generate shopping lists, run a local server, and automate your cooking workflow.
           </p>
-          <a href="/cli/" class="text-cooklang-orange hover:underline">Explore CLI →</a>
+          <a href="/cli/" class="text-cooklang-orange hover:underline">Explore CookCLI →</a>
         </article>
         <article class="bg-white p-6 rounded-lg shadow-sm">
           <div class="w-12 h-12 bg-cooklang-orange/10 rounded-lg flex items-center justify-center mb-4">


### PR DESCRIPTION
From the 2026-09-01 GSC read (growth repo `docs/2026-09-01-seo-priorities.md`, items O1–O4 + O6 anchor).

- **O1 — the main lever:** `21-self-hosting-recipes-with-docker` is top of page 2 (pos 11.2) with **4.76% CTR when seen** — people click it, they just don't see it. Adds descriptive-anchor links from the four strongest pages: `42-tandoor-vs-mealie-vs-kitchenowl` (the 252-click star), `40-mealie-review`, `18-open-source-recipe-managers-2026`, `48-best`. Each link placed where the surrounding text already discusses Docker/servers, honest about the guide being CookCLI-based.
- **O3:** `docs/spec` title → "Cooklang Specification & Syntax Reference" — "cooklang syntax" ranked pos ~20 for the language's own syntax query.
- **O4:** exact-anchor "CookCLI" links from the homepage card ("Explore CLI →" → "Explore CookCLI →") and `getting-started` — the "cookcli" query sits pos 11.
- **O2:** `26-scale-recipes` (18k impr @ 0.4%) gains a "### How to double a recipe" 4-step ordered list for featured-snippet eligibility, matching its how-to query shapes; content consistent with the post's existing rules table.
- **O6:** `40-mealie-review`'s comparison link anchor now says "Mealie vs Paprika vs Cooklang" (those vs-queries already convert ~12%).

Layout change is anchor text only — no new Tailwind utilities, CSS not rebuilt (per the repo's prebuilt-CSS rule). `hugo` builds clean. Merging to main deploys via gh-pages.

https://claude.ai/code/session_01Q8pkqiD5Udvi7BBvKmNeus